### PR TITLE
Adds support for trogon.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -67,6 +67,9 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 ignore_errors = True
 
+[mypy-trogon.*]
+ignore_missing_imports = True
+
 [mypy-varats.gui.views.*]
 ignore_errors = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ rich>=12.6
 scikit-learn>=1.2.2
 seaborn>=0.13.0
 tabulate>=0.9
+trogon>=0.5.0
 types-PyYAML
 types-requests
 types-tabulate

--- a/tests/tools/test_driver_artefacts.py
+++ b/tests/tools/test_driver_artefacts.py
@@ -1,16 +1,16 @@
 """Test artefacts config tool."""
-import traceback
+import importlib
 import unittest
 
 from click.testing import CliRunner
 
+import varats.tools.driver_artefacts as driver_artefacts
 from tests.helper_utils import run_in_test_environment, UnitTestFixtures
 from varats.data.discover_reports import initialize_reports
 from varats.paper.paper_config import get_paper_config, load_paper_config
 from varats.paper_mgmt.artefacts import Artefact, load_artefacts
 from varats.plots.discover_plots import initialize_plots
 from varats.tables.discover_tables import initialize_tables
-from varats.tools import driver_artefacts
 from varats.utils.settings import vara_cfg
 
 
@@ -32,6 +32,7 @@ class TestDriverArtefacts(unittest.TestCase):
         # setup config
         vara_cfg()['paper_config']['current_config'] = "test_artefacts_driver"
         load_paper_config()
+        importlib.reload(driver_artefacts)
         artefacts = load_artefacts(get_paper_config()).artefacts
         base_output_dir = Artefact.base_output_dir()
 
@@ -59,8 +60,9 @@ class TestDriverArtefacts(unittest.TestCase):
         # setup config
         vara_cfg()['paper_config']['current_config'] = "test_artefacts_driver"
         load_paper_config()
+        importlib.reload(driver_artefacts)
 
-        # vara-art generate
+        # vara-art list
         runner = CliRunner()
         result = runner.invoke(driver_artefacts.main, ["list"])
         self.assertEqual(0, result.exit_code, result.exception)
@@ -76,6 +78,16 @@ class TestDriverArtefacts(unittest.TestCase):
         # setup config
         vara_cfg()['paper_config']['current_config'] = "test_artefacts_driver"
         load_paper_config()
+        importlib.reload(driver_artefacts)
+
+        # vara-art list
+        runner = CliRunner()
+        result = runner.invoke(driver_artefacts.main, ["list"])
+        self.assertEqual(0, result.exit_code, result.exception)
+        self.assertEqual(
+            "Paper Config Overview [plot]\nCorrelation Table [table]\n"
+            "CS Overview (xz) [plot]\nRepo Churn (all) [plot]\n", result.stdout
+        )
 
         expected = r"""Artefact 'Paper Config Overview':
   artefact_type: plot
@@ -91,7 +103,7 @@ class TestDriverArtefacts(unittest.TestCase):
 
 """
 
-        # vara-art generate
+        # vara-art show
         runner = CliRunner()
         result = runner.invoke(
             driver_artefacts.main, ["show", "Paper Config Overview"]

--- a/tests/tools/test_driver_paper_config.py
+++ b/tests/tools/test_driver_paper_config.py
@@ -54,7 +54,7 @@ class TestDriverPaperConfig(unittest.TestCase):
         vara_cfg()["paper_config"]["current_config"] = "foo"
         load_paper_config()
         result = runner.invoke(driver_paper_config.main, ["select"], input="1")
-        assert not result.exception
+        self.assertFalse(result.exception)
         self.assertEqual(
             "0. bar\n1. baz\n2. foo *\n"
             "Choose a number to select a paper config (default=0): ",

--- a/varats/setup.py
+++ b/varats/setup.py
@@ -42,6 +42,7 @@ setup(
         "scikit-learn>=1.2.2",
         "seaborn>=0.13.0",
         "tabulate>=0.9",
+        "trogon>=0.5.0",
         "varats-core>=13.0.5",
         "wllvm>=1.3.1",
     ],

--- a/varats/varats/tools/driver_artefacts.py
+++ b/varats/varats/tools/driver_artefacts.py
@@ -27,17 +27,25 @@ from varats.plots.discover_plots import initialize_plots
 from varats.projects.discover_projects import initialize_projects
 from varats.tables.discover_tables import initialize_tables
 from varats.ts_utils.cli_util import initialize_cli_tool
+from varats.ts_utils.click_param_types import TypedChoice
 from varats.ts_utils.html_util import (
     CSS_IMAGE_MATRIX,
     CSS_COMMON,
     html_page,
     CSS_TABLE,
 )
+from varats.utils.exceptions import ConfigurationLookupError
 
 LOG = logging.getLogger(__name__)
 
+initialize_projects()
+initialize_reports()
+initialize_tables()
+initialize_plots()
+initialize_artefact_types()
 
-@tui()
+
+@tui()  # type: ignore
 @click.group(
     help="Manage artefacts.",
     context_settings={"help_option_names": ['-h', '--help']}
@@ -49,15 +57,10 @@ def main() -> None:
     `vara-art`
     """
     initialize_cli_tool()
-    initialize_projects()
-    initialize_reports()
-    initialize_tables()
-    initialize_plots()
-    initialize_artefact_types()
 
 
 # function name `list` would shadow built-in `list`
-@main.command(
+@main.command(  # type: ignore
     name="list", help="List all artefacts of the current paper config."
 )
 def list_() -> None:
@@ -68,49 +71,52 @@ def list_() -> None:
         print(f"{artefact.name} [{artefact.ARTEFACT_TYPE}]")
 
 
-@main.command(help="Show detailed information about artefacts.")
-@click.argument("name")
-def show(name: str) -> None:
+def _create_artefact_choice() -> TypedChoice['Artefact']:
+    try:
+        paper_config = get_paper_config()
+    except ConfigurationLookupError:
+        empty_art_dict: tp.Dict[str, 'Artefact'] = {}
+        return TypedChoice(empty_art_dict)
+    value_dict = {art.name: art for art in load_artefacts(paper_config)}
+    return TypedChoice(value_dict)
+
+
+@main.command(help="Show detailed information about artefacts.")  # type: ignore
+@click.argument("name", type=_create_artefact_choice())
+def show(name: Artefact) -> None:
     """
     Show detailed information about artefacts.
 
     Args:
-        name: the name of the artefact
+        name: the artefact to display
     """
-    paper_config = get_paper_config()
-    if (artefact := load_artefacts(paper_config).get_artefact(name)):
-        print(f"Artefact '{name}':")
-        print(textwrap.indent(yaml.dump(artefact.get_dict()), '  '))
-    else:
-        print(f"There is no artefact with the name {name}.")
+    print(textwrap.indent(yaml.dump(name.get_dict()), '  '))
 
 
-@main.command(
+@main.command(  # type: ignore
     help="Generate artefacts. By default, all artefacts are generated."
 )
 @click.option(
     "--only",
+    type=_create_artefact_choice(),
     multiple=True,
     help="Only generate artefacts with the given names."
 )
-def generate(only: tp.Optional[str]) -> None:
+def generate(only: tp.List[Artefact]) -> None:
     """
     Generate artefacts.
 
     By default, all artefacts are generated.
 
     Args:
-        only: generate only this artefact
+        only: generate only these artefacts
     """
     if not Artefact.base_output_dir().exists():
         Artefact.base_output_dir().mkdir(parents=True)
     artefacts: tp.Iterable[Artefact]
 
     if only:
-        artefacts = [
-            art for art in load_artefacts(get_paper_config())
-            if art.name in only
-        ]
+        artefacts = only
     else:
         artefacts = load_artefacts(get_paper_config())
 

--- a/varats/varats/tools/driver_artefacts.py
+++ b/varats/varats/tools/driver_artefacts.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import click
 import yaml
 from rich.progress import Progress
+from trogon import tui
 
 from varats.data.discover_reports import initialize_reports
 from varats.paper.paper_config import get_paper_config
@@ -36,6 +37,7 @@ from varats.ts_utils.html_util import (
 LOG = logging.getLogger(__name__)
 
 
+@tui()
 @click.group(
     help="Manage artefacts.",
     context_settings={"help_option_names": ['-h', '--help']}

--- a/varats/varats/tools/driver_artefacts.py
+++ b/varats/varats/tools/driver_artefacts.py
@@ -82,15 +82,16 @@ def _create_artefact_choice() -> TypedChoice['Artefact']:
 
 
 @main.command(help="Show detailed information about artefacts.")  # type: ignore
-@click.argument("name", type=_create_artefact_choice())
-def show(name: Artefact) -> None:
+@click.argument("artefact", type=_create_artefact_choice())
+def show(artefact: Artefact) -> None:
     """
     Show detailed information about artefacts.
 
     Args:
-        name: the artefact to display
+        artefact: the artefact to display
     """
-    print(textwrap.indent(yaml.dump(name.get_dict()), '  '))
+    print(f"Artefact '{artefact.name}':")
+    print(textwrap.indent(yaml.dump(artefact.get_dict()), '  '))
 
 
 @main.command(  # type: ignore

--- a/varats/varats/tools/driver_build_setup.py
+++ b/varats/varats/tools/driver_build_setup.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import click
 from plumbum import colors
+from trogon import tui
 
 from varats.containers.containers import (
     ImageBase,
@@ -89,6 +90,7 @@ def show_major_release_prompt(
         return
 
 
+@tui()
 @click.group(context_settings={"help_option_names": ['-h', '--help']})
 def main() -> None:
     """Build VaRA on cli."""
@@ -170,7 +172,7 @@ def update(research_tool: str) -> None:
 @click.option(
     "--build-type",
     type=EnumChoice(BuildType, case_sensitive=False),
-    default=BuildType.DEV,
+    default="DEV",
     help="Build type to use for the tool build configuration."
 )
 @click.option(

--- a/varats/varats/tools/driver_build_setup.py
+++ b/varats/varats/tools/driver_build_setup.py
@@ -90,14 +90,14 @@ def show_major_release_prompt(
         return
 
 
-@tui()
+@tui()  # type: ignore
 @click.group(context_settings={"help_option_names": ['-h', '--help']})
 def main() -> None:
     """Build VaRA on cli."""
     initialize_cli_tool()
 
 
-@main.command()
+@main.command()  # type: ignore
 def config() -> None:
     """Only create a VaRA-TS config file."""
     save_config()
@@ -125,7 +125,7 @@ def config() -> None:
     required=False,
     help="Tool install folder."
 )
-@main.command()
+@main.command()  # type: ignore
 def init(
     version: tp.Optional[int], install_prefix: tp.Optional[Path],
     source_location: tp.Optional[Path], research_tool: str
@@ -138,7 +138,7 @@ def init(
 @click.argument(
     "research_tool", type=click.Choice(get_supported_research_tool_names())
 )
-@main.command()
+@main.command()  # type: ignore
 def update(research_tool: str) -> None:
     """Update a research tool and all its components."""
     tool = get_research_tool(research_tool)
@@ -180,7 +180,7 @@ def update(research_tool: str) -> None:
     default=True,
     help="Show a prompt to check for major version updates."
 )
-@main.command()
+@main.command()  # type: ignore
 def build(
     research_tool: str, build_type: BuildType,
     build_folder_suffix: tp.Optional[str], source_location: tp.Optional[Path],

--- a/varats/varats/tools/driver_casestudy.py
+++ b/varats/varats/tools/driver_casestudy.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import click
 from plumbum import FG, colors, local
+from trogon import tui
 
 from varats.base.sampling_method import NormalSamplingMethod
 from varats.data.discover_reports import initialize_reports
@@ -86,6 +87,7 @@ def create_plot_type_choice() -> TypedChoice[tp.Type[Plot]]:
     return TypedChoice(Plot.PLOTS)
 
 
+@tui()
 @click.group()
 @configuration_lookup_error_handler
 def main() -> None:

--- a/varats/varats/tools/driver_casestudy.py
+++ b/varats/varats/tools/driver_casestudy.py
@@ -401,7 +401,7 @@ class SmoothPlotCLI(click.MultiCommand):
 
         generator_cls = PlotGenerator.GENERATORS[cmd_name]
 
-        @click.pass_context
+        @click.pass_context  # type: ignore
         def command_template(context: click.Context, **kwargs: tp.Any) -> None:
             # extract common arguments and plot config from context
             plot_config: PlotConfig = PlotConfig(False)

--- a/varats/varats/tools/driver_config.py
+++ b/varats/varats/tools/driver_config.py
@@ -16,7 +16,7 @@ from trogon import tui
 from varats.utils.settings import vara_cfg, save_config
 
 
-@tui()
+@tui()  # type: ignore
 @click.group("vara-config")
 def main() -> None:
     """
@@ -54,7 +54,7 @@ def __dump_config_to_string(config: Configuration) -> str:
     )
 
 
-@main.command("set")
+@main.command("set")  # type: ignore
 @click.argument("config_values", nargs=-1, metavar="KEY=VALUE")
 def __config_set(config_values: tp.List[str]) -> None:
     """
@@ -80,7 +80,7 @@ def __config_set(config_values: tp.List[str]) -> None:
     save_config()
 
 
-@main.command("show")
+@main.command("show")  # type: ignore
 @click.argument("config_options", nargs=-1)
 def __config_show(config_options: tp.Optional[tp.List[str]]) -> None:
     """

--- a/varats/varats/tools/driver_config.py
+++ b/varats/varats/tools/driver_config.py
@@ -11,10 +11,12 @@ import typing as tp
 import click
 import yaml
 from benchbuild.utils.settings import ConfigDumper, Configuration
+from trogon import tui
 
 from varats.utils.settings import vara_cfg, save_config
 
 
+@tui()
 @click.group("vara-config")
 def main() -> None:
     """

--- a/varats/varats/tools/driver_container.py
+++ b/varats/varats/tools/driver_container.py
@@ -27,7 +27,7 @@ from varats.utils.settings import vara_cfg, save_config, bb_cfg
 LOG = logging.Logger(__name__)
 
 
-@tui()
+@tui()  # type: ignore
 @click.group(
     help="Manage base container images.",
     context_settings={"help_option_names": ['-h', '--help']}
@@ -38,7 +38,9 @@ def main() -> None:
     bb_cfg()
 
 
-@main.command(help="Build base containers for the current research tool.")
+@main.command(
+    help="Build base containers for the current research tool."
+)  # type: ignore
 @click.option(
     "--debug", is_flag=True, help="Debug failed image builds interactively."
 )
@@ -103,7 +105,9 @@ def build(
             export_base_images()
 
 
-@main.command(help="Delete base containers for the current research tool.")
+@main.command(
+    help="Delete base containers for the current research tool."
+)  # type: ignore
 @click.option(
     "--build-type",
     type=EnumChoice(BuildType, case_sensitive=False),
@@ -141,7 +145,9 @@ def delete(
             delete_base_images()
 
 
-@main.command(help="Select the research tool to be used in base containers.")
+@main.command(
+    help="Select the research tool to be used in base containers."
+)  # type: ignore
 @click.option(
     "-t",
     "--tool",

--- a/varats/varats/tools/driver_container.py
+++ b/varats/varats/tools/driver_container.py
@@ -8,6 +8,7 @@ import logging
 import typing as tp
 
 import click
+from trogon import tui
 
 from varats.containers.containers import (
     create_base_images,
@@ -26,6 +27,7 @@ from varats.utils.settings import vara_cfg, save_config, bb_cfg
 LOG = logging.Logger(__name__)
 
 
+@tui()
 @click.group(
     help="Manage base container images.",
     context_settings={"help_option_names": ['-h', '--help']}
@@ -144,7 +146,8 @@ def delete(
     "-t",
     "--tool",
     type=click.Choice([*get_supported_research_tool_names(), "none"]),
-    default=lambda: vara_cfg()["container"]["research_tool"].value or "none",
+    required=True,
+    # default=lambda: vara_cfg()["container"]["research_tool"].value or "none",
     prompt="Select a research tool to activate.",
     help="The research tool to activate."
 )

--- a/varats/varats/tools/driver_develop.py
+++ b/varats/varats/tools/driver_develop.py
@@ -14,7 +14,7 @@ from varats.tools.tool_util import (
 from varats.ts_utils.cli_util import initialize_cli_tool
 
 
-@tui()
+@tui()  # type: ignore
 @click.group(context_settings={"help_option_names": ['-h', '--help']})
 @click.option(
     "-p",
@@ -57,7 +57,7 @@ def main(
     context.obj["project_list"] = project_list
 
 
-@main.command(help="Create a new branch.")
+@main.command(help="Create a new branch.")  # type: ignore
 @click.argument("branch_name", type=str)
 @click.pass_context
 def new_branch(context: click.Context, branch_name: str) -> None:
@@ -65,7 +65,7 @@ def new_branch(context: click.Context, branch_name: str) -> None:
     dev.create_new_branch_for_projects(branch_name, context.obj["project_list"])
 
 
-@main.command(help="Checkout a branch.")
+@main.command(help="Checkout a branch.")  # type: ignore
 @click.argument("branch_name", type=str)
 @click.pass_context
 def checkout(context: click.Context, branch_name: str) -> None:
@@ -75,28 +75,28 @@ def checkout(context: click.Context, branch_name: str) -> None:
     )
 
 
-@main.command(help="Git pull the research tool's repository.")
+@main.command(help="Git pull the research tool's repository.")  # type: ignore
 @click.pass_context
 def pull(context: click.Context) -> None:
     """Git pull the research tool's repository."""
     dev.pull_projects(context.obj["project_list"])
 
 
-@main.command(help="Git push the research tool's repository.")
+@main.command(help="Git push the research tool's repository.")  # type: ignore
 @click.pass_context
 def push(context: click.Context) -> None:
     """Git push the research tool's repository."""
     dev.push_projects(context.obj["project_list"])
 
 
-@main.command(help="Show git status for a research tool.")
+@main.command(help="Show git status for a research tool.")  # type: ignore
 @click.pass_context
 def status(context: click.Context) -> None:
     """Show git status for a research tool."""
     dev.show_status_for_projects(context.obj["project_list"])
 
 
-@main.command(help="List all remote feature branches.")
+@main.command(help="List all remote feature branches.")  # type: ignore
 @click.pass_context
 def f_branches(context: click.Context) -> None:
     """List all remote feature branches."""

--- a/varats/varats/tools/driver_develop.py
+++ b/varats/varats/tools/driver_develop.py
@@ -3,6 +3,7 @@
 import typing as tp
 
 import click
+from trogon import tui
 
 from varats.tools.research_tools import development as dev
 from varats.tools.research_tools.research_tool import SubProject
@@ -13,6 +14,7 @@ from varats.tools.tool_util import (
 from varats.ts_utils.cli_util import initialize_cli_tool
 
 
+@tui()
 @click.group(context_settings={"help_option_names": ['-h', '--help']})
 @click.option(
     "-p",

--- a/varats/varats/tools/driver_gen_benchbuild_config.py
+++ b/varats/varats/tools/driver_gen_benchbuild_config.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger(__name__)
 
 
 @tui()  # type: ignore
-@click.command()
+@click.group(invoke_without_command=True)
 @click.option(
     "--bb-root",
     type=click.Path(),

--- a/varats/varats/tools/driver_gen_benchbuild_config.py
+++ b/varats/varats/tools/driver_gen_benchbuild_config.py
@@ -6,6 +6,7 @@ import sys
 import typing as tp
 
 import click
+from trogon import tui
 
 from varats.tools.bb_config import (
     create_new_bb_config,
@@ -18,6 +19,7 @@ from varats.utils.settings import save_config, vara_cfg, save_bb_config, bb_cfg
 LOG = logging.getLogger(__name__)
 
 
+@tui()
 @click.command()
 @click.option(
     "--bb-root",

--- a/varats/varats/tools/driver_gen_benchbuild_config.py
+++ b/varats/varats/tools/driver_gen_benchbuild_config.py
@@ -19,7 +19,7 @@ from varats.utils.settings import save_config, vara_cfg, save_bb_config, bb_cfg
 LOG = logging.getLogger(__name__)
 
 
-@tui()
+@tui()  # type: ignore
 @click.command()
 @click.option(
     "--bb-root",

--- a/varats/varats/tools/driver_paper_config.py
+++ b/varats/varats/tools/driver_paper_config.py
@@ -24,7 +24,7 @@ from varats.utils.settings import (
 LOG = logging.getLogger(__name__)
 
 
-@tui()
+@tui()  # type: ignore
 @click.group("vara-pc")
 def main() -> None:
     """
@@ -34,85 +34,56 @@ def main() -> None:
     """
     initialize_cli_tool()
 
-    if vara_cfg()["paper_config"]["folder"].value is None:
-        # Setup default paper config path when none exists
-        vara_cfg()["paper_config"]["folder"] = str(
-            Path('paper_configs').absolute()
-        )
-        save_config()
 
-
-def _get_paper_configs(pc_folder_path: Path) -> tp.List[str]:
+def _get_paper_configs() -> tp.List[str]:
     paper_configs: tp.List[str] = []
-    for folder in pc_folder_path.iterdir():
+    for folder in Path(vara_cfg()["paper_config"]["folder"].value).iterdir():
         paper_configs.append(folder.name)
     return sorted(paper_configs)
 
 
-@main.command("create")
-@click.argument("paper_config", type=click.Path())
+@main.command("create")  # type: ignore
+@click.argument("paper_config")
 def _pc_create(paper_config: str) -> None:
-    """paper_config:
-            Path to the new paper config.
-             Relative paths are interpreted relative to the current
-             `paper_config/folder`."""
-    pc_path: Path = Path(paper_config)
-    if not pc_path.is_absolute():
-        current_folder = vara_cfg()["paper_config"]["folder"].value
-        if current_folder is None:
-            pc_path = Path(
-                vara_cfg()["config_file"].value
-            ).parent / "paper_configs" / pc_path
-        else:
-            pc_path = Path(current_folder) / pc_path
+    """Create a new paper config."""
+    pc_folder_path = Path(vara_cfg()["paper_config"]["folder"].value)
+    pc_path = pc_folder_path / paper_config
 
     if pc_path.exists():
         LOG.error(
-            f"Cannot create paper config at: {pc_path} "
-            "(Path already exists)."
+            f"Cannot create paper config at: {pc_path} (Path already exists)."
         )
         return
 
-    folder = pc_path.parent
-    current_config = pc_path.name
-
-    LOG.info(
-        f"Creating new paper config {current_config} at location {folder}."
-    )
+    LOG.info(f"Creating new paper config {paper_config} at location {pc_path}.")
     pc_path.mkdir(parents=True)
 
-    vara_cfg()["paper_config"]["folder"] = str(folder)
-    vara_cfg()["paper_config"]["current_config"] = str(current_config)
+    # automatically select new paper config
+    vara_cfg()["paper_config"]["current_config"] = paper_config
     save_config()
 
 
-@main.command("select")
-@click.option("--paper-config", type=click.Path())
-def _pc_set(paper_config: tp.Optional[Path]) -> None:
+def create_pc_choice() -> click.Choice:
+    paper_configs = _get_paper_configs()
+    return click.Choice(paper_configs)
+
+
+@main.command("select")  # type: ignore
+@click.option("--paper-config", type=create_pc_choice(), required=True)
+def _pc_set(paper_config: tp.Optional[str]) -> None:
     if not paper_config:
-        pc_folder_path = Path(
-            get_value_or_default(
-                vara_cfg()["paper_config"], "folder",
-                str(get_varats_base_folder())
-            )
-        )
-        if not (pc_folder_path.exists() and pc_folder_path.is_dir()):
-            LOG.error(
-                f"Paper config folder not set: {pc_folder_path} "
-                "(Path does not exist or is no directory)."
-            )
-            return
+        pc_folder_path = Path(vara_cfg()["paper_config"]["folder"].value)
 
-        paper_configs = _get_paper_configs(pc_folder_path)
+        paper_configs = _get_paper_configs()
         if not paper_configs:
-            LOG.error(f"Could not find paper configs in: {pc_folder_path}")
+            LOG.error(f"Could not find any paper configs.")
             return
 
-        raw_pc_path = None
+        selected_paper_config = None
 
         def set_pc_path(choice: str) -> None:
-            nonlocal raw_pc_path
-            raw_pc_path = choice
+            nonlocal selected_paper_config
+            selected_paper_config = choice
 
         current_config = None
         try:
@@ -129,51 +100,17 @@ def _pc_set(paper_config: tp.Optional[Path]) -> None:
             )
         except EOFError:
             return
-        if raw_pc_path is None:
+        if selected_paper_config is None:
             raise AssertionError("Choice should always return a value")
-        paper_config = Path(raw_pc_path)
+        paper_config = selected_paper_config
 
-    paper_config = Path(paper_config)
-    if not paper_config.is_absolute():
-        paper_config = Path(
-            vara_cfg()["paper_config"]["folder"].value
-        ) / paper_config
-
-    if not (paper_config.exists() and paper_config.is_dir()):
-        LOG.error(
-            f"Not a paper config: {paper_config} "
-            "(Path does not exist or is no directory)."
-        )
-        return
-
-    folder = paper_config.parent
-    current_config = paper_config.name
-
-    LOG.info(
-        f"Current paper config is now {current_config} at location {folder}."
-    )
-    vara_cfg()["paper_config"]["folder"] = str(folder)
-    vara_cfg()["paper_config"]["current_config"] = str(current_config)
+    LOG.info(f"Current paper config is now {paper_config}.")
+    vara_cfg()["paper_config"]["current_config"] = paper_config
     save_config()
 
 
-@main.command("list")
-@click.option(
-    "--paper-config-path",
-    help="Path to the paper config folder.",
-    type=click.Path()
-)
-def _pc_list(paper_config_path: tp.Optional[Path]) -> None:
-    if not paper_config_path:
-        paper_config_path = Path(vara_cfg()["paper_config"]["folder"].value)
-
-    if not (paper_config_path.exists() and paper_config_path.is_dir()):
-        LOG.error(
-            f"Paper config folder not found: {paper_config_path} "
-            "(Path does not exist or is no directory)."
-        )
-        return
-
+@main.command("list")  # type: ignore
+def _pc_list() -> None:
     print("Found the following paper_configs:")
     current_config = None
     try:
@@ -182,7 +119,7 @@ def _pc_list(paper_config_path: tp.Optional[Path]) -> None:
         # No paper config specified in the varats config file
         pass
 
-    for paper_config in _get_paper_configs(paper_config_path):
+    for paper_config in _get_paper_configs():
         if current_config and paper_config == current_config:
             print(f"{paper_config} *")
         else:

--- a/varats/varats/tools/driver_paper_config.py
+++ b/varats/varats/tools/driver_paper_config.py
@@ -69,7 +69,7 @@ def create_pc_choice() -> click.Choice:
 
 
 @main.command("select")  # type: ignore
-@click.option("--paper-config", type=create_pc_choice(), required=True)
+@click.option("--paper-config", type=create_pc_choice())
 def _pc_set(paper_config: tp.Optional[str]) -> None:
     if not paper_config:
         pc_folder_path = Path(vara_cfg()["paper_config"]["folder"].value)

--- a/varats/varats/tools/driver_paper_config.py
+++ b/varats/varats/tools/driver_paper_config.py
@@ -9,6 +9,7 @@ import typing as tp
 from pathlib import Path
 
 import click
+from trogon import tui
 
 from varats.paper.paper_config import get_paper_config
 from varats.ts_utils.cli_util import cli_list_choice, initialize_cli_tool
@@ -23,6 +24,7 @@ from varats.utils.settings import (
 LOG = logging.getLogger(__name__)
 
 
+@tui()
 @click.group("vara-pc")
 def main() -> None:
     """

--- a/varats/varats/tools/driver_run.py
+++ b/varats/varats/tools/driver_run.py
@@ -82,7 +82,7 @@ def __validate_project_parameters(
     return value
 
 
-@tui()
+@tui()  # type: ignore
 @click.command(context_settings={"help_option_names": ['-h', '--help']})
 @click.option('-v', '--verbose', count=True)
 @click.option("--slurm", is_flag=True, help="Run experiments on slurm.")

--- a/varats/varats/tools/driver_run.py
+++ b/varats/varats/tools/driver_run.py
@@ -19,6 +19,7 @@ from benchbuild.utils.cmd import benchbuild, sbatch
 from benchbuild.utils.settings import to_yaml
 from plumbum import local
 from plumbum.commands import ProcessExecutionError
+from trogon import tui
 
 from varats.paper.case_study import CaseStudy
 from varats.paper.paper_config import get_paper_config
@@ -81,6 +82,7 @@ def __validate_project_parameters(
     return value
 
 
+@tui()
 @click.command(context_settings={"help_option_names": ['-h', '--help']})
 @click.option('-v', '--verbose', count=True)
 @click.option("--slurm", is_flag=True, help="Run experiments on slurm.")

--- a/varats/varats/tools/driver_run.py
+++ b/varats/varats/tools/driver_run.py
@@ -19,7 +19,6 @@ from benchbuild.utils.cmd import benchbuild, sbatch
 from benchbuild.utils.settings import to_yaml
 from plumbum import local
 from plumbum.commands import ProcessExecutionError
-from trogon import tui
 
 from varats.paper.case_study import CaseStudy
 from varats.paper.paper_config import get_paper_config
@@ -82,7 +81,6 @@ def __validate_project_parameters(
     return value
 
 
-@tui()  # type: ignore
 @click.command(context_settings={"help_option_names": ['-h', '--help']})
 @click.option('-v', '--verbose', count=True)
 @click.option("--slurm", is_flag=True, help="Run experiments on slurm.")


### PR DESCRIPTION
Most vara-* commands now support `tui` as a subcommand which opens a text-based UI for selecting command line parameters.

Some limitations apply:
- `vara-run` is not supported because arguments do not play nice with command groups in click
- `vara-plot` and `vara-table` require support for `click.MultiCommand` (Textualize/trogon#71)
- `trogon` contains some more small bugs that limit usability. I opened PRs for them, but until they are merged, you can use the following branch for testing: https://github.com/boehmseb/trogon/tree/trogonFixes