### PR TITLE
Implements out-of-tree loading support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: ['--django']
         exclude: 'tests/helper_utils.py'
   - repo: https://github.com/timothycrosley/isort.git
-    rev: 6.0.0
+    rev: 6.0.1
     hooks:
       - id: isort
         args: ['--nis']

--- a/varats-core/varats/utils/external_source_handling.py
+++ b/varats-core/varats/utils/external_source_handling.py
@@ -1,0 +1,57 @@
+"""
+Module for handling external varats sources.
+
+This module provides loading facilities for loading custom user
+projects/experiments/etc. into the varats ecosystem.
+"""
+
+import importlib
+import logging
+import pkgutil
+import sys
+import typing as tp
+from pathlib import Path
+
+LOG = logging.getLogger(__name__)
+
+
+def determine_project_source_root(project_folder: Path) -> Path:
+    return project_folder / project_folder.name
+
+
+def relative_module_folder(project_folder: Path, module_folder: Path) -> Path:
+    return module_folder.absolute().relative_to(project_folder.absolute())
+
+
+def convert_path_to_module_path(path: Path) -> str:
+    return str(path).replace('/', '.')
+
+
+def load_python_modules_from_external_project(
+    project_folder: Path,
+    module_folder: Path,
+    export_context: tp.Optional[tp.List[tp.Any]] = None
+) -> None:
+    """
+    Load additional python modules from a external project.
+
+    Args:
+        project_folder: of the project we want to load from
+        module_folder: that we want to load
+        export_context: into which we want to export our modules (e.g., __all__)
+    """
+    if str(project_folder) not in sys.path:
+        sys.path.insert(1, str(project_folder))
+
+    relative_mf = relative_module_folder(
+        project_folder=project_folder, module_folder=module_folder
+    )
+    module_prefix = f"{convert_path_to_module_path(relative_mf)}."
+
+    for _, module_name, _ in pkgutil.walk_packages([str(module_folder)],
+                                                   module_prefix):
+        if export_context:
+            export_context.append(module_name)
+
+        _module = importlib.import_module(module_name)
+        globals()[module_name] = _module

--- a/varats-core/varats/utils/settings.py
+++ b/varats-core/varats/utils/settings.py
@@ -43,6 +43,12 @@ def create_new_varats_config() -> s.Configuration:
                 "desc": "Result folder for collected results",
                 "default": os.getcwd() + "/results",
             },
+            "external_source_repositories": {
+                "desc":
+                    "List of external repositories from where we local extra "
+                    "projects/experiments/tables/plots.",
+                "default": []
+            },
         }
     )
 

--- a/varats/varats/data/discover_reports.py
+++ b/varats/varats/data/discover_reports.py
@@ -3,8 +3,13 @@
 from varats import report as __CORE_REPORTS__
 from varats.data import reports as __REPORTS__
 
+__REPORTS_DISCOVERED = False
+
 
 def initialize_reports() -> None:
-    # Discover and initialize all Reports
-    __REPORTS__.discover()
-    __CORE_REPORTS__.discover()
+    global __REPORTS_DISCOVERED  # pylint: disable=global-statement
+    if not __REPORTS_DISCOVERED:
+        # Discover and initialize all Reports
+        __REPORTS__.discover()
+        __CORE_REPORTS__.discover()
+        __REPORTS_DISCOVERED = True

--- a/varats/varats/data/reports/__init__.py
+++ b/varats/varats/data/reports/__init__.py
@@ -2,6 +2,10 @@
 
 import importlib
 import pkgutil
+from pathlib import Path
+
+import varats.utils.external_source_handling as esh
+from varats.utils.settings import vara_cfg
 
 
 def discover() -> None:
@@ -13,3 +17,8 @@ def discover() -> None:
         __all__.append(module_name)
         _module = importlib.import_module(module_name)
         globals()[module_name] = _module
+
+    extra_sources = vara_cfg()['external_source_repositories'].value
+    for p in [Path(p) for p in extra_sources]:
+        module_folder = esh.determine_project_source_root(p) / "reports"
+        esh.load_python_modules_from_external_project(p, module_folder, __all__)

--- a/varats/varats/experiments/__init__.py
+++ b/varats/varats/experiments/__init__.py
@@ -2,14 +2,25 @@
 
 import importlib
 import pkgutil
+from pathlib import Path
+
+import varats.utils.external_source_handling as esh
+from varats.utils.settings import vara_cfg
 
 
 def discover() -> None:
     """Auto import all BenchBuild experiments."""
+
     __all__ = []
+
     for _, module_name, _ in pkgutil.walk_packages(
         __path__, 'varats.experiments.'
     ):
         __all__.append(module_name)
         _module = importlib.import_module(module_name)
         globals()[module_name] = _module
+
+    extra_sources = vara_cfg()['external_source_repositories'].value
+    for p in [Path(p) for p in extra_sources]:
+        module_folder = esh.determine_project_source_root(p) / "experiments"
+        esh.load_python_modules_from_external_project(p, module_folder, __all__)

--- a/varats/varats/experiments/discover_experiments.py
+++ b/varats/varats/experiments/discover_experiments.py
@@ -2,7 +2,12 @@
 
 from varats import experiments as __EXPERIMENTS__
 
+__EXPERIMENTS_DISCOVERED: bool = False
+
 
 def initialize_experiments() -> None:
-    # Discover and initialize all Reports
-    __EXPERIMENTS__.discover()
+    global __EXPERIMENTS_DISCOVERED  # pylint: disable=global-statement
+    if not __EXPERIMENTS_DISCOVERED:
+        # Discover and initialize all Experiments
+        __EXPERIMENTS__.discover()
+        __EXPERIMENTS_DISCOVERED = True

--- a/varats/varats/plots/__init__.py
+++ b/varats/varats/plots/__init__.py
@@ -2,6 +2,10 @@
 
 import importlib
 import pkgutil
+from pathlib import Path
+
+import varats.utils.external_source_handling as esh
+from varats.utils.settings import vara_cfg
 
 
 def discover() -> None:
@@ -13,3 +17,8 @@ def discover() -> None:
         __all__.append(module_name)
         _module = importlib.import_module(module_name)
         globals()[module_name] = _module
+
+    extra_sources = vara_cfg()['external_source_repositories'].value
+    for p in [Path(p) for p in extra_sources]:
+        module_folder = esh.determine_project_source_root(p) / "plots"
+        esh.load_python_modules_from_external_project(p, module_folder, __all__)

--- a/varats/varats/plots/discover_plots.py
+++ b/varats/varats/plots/discover_plots.py
@@ -2,7 +2,12 @@
 
 from varats import plots as __PLOTS__
 
+__PLOTS_DISCOVERED = False
+
 
 def initialize_plots() -> None:
-    # Discover and initialize all plots
-    __PLOTS__.discover()
+    global __PLOTS_DISCOVERED  # pylint: disable=global-statement
+    if not __PLOTS_DISCOVERED:
+        # Discover and initialize all plots
+        __PLOTS__.discover()
+        __PLOTS_DISCOVERED = True

--- a/varats/varats/projects/__init__.py
+++ b/varats/varats/projects/__init__.py
@@ -2,6 +2,10 @@
 
 import importlib
 import pkgutil
+from pathlib import Path
+
+import varats.utils.external_source_handling as esh
+from varats.utils.settings import vara_cfg
 
 
 def discover() -> None:
@@ -13,3 +17,8 @@ def discover() -> None:
         __all__.append(module_name)
         _module = importlib.import_module(module_name)
         globals()[module_name] = _module
+
+    extra_sources = vara_cfg()['external_source_repositories'].value
+    for p in [Path(p) for p in extra_sources]:
+        module_folder = esh.determine_project_source_root(p) / "projects"
+        esh.load_python_modules_from_external_project(p, module_folder, __all__)

--- a/varats/varats/projects/discover_projects.py
+++ b/varats/varats/projects/discover_projects.py
@@ -2,14 +2,14 @@
 
 from varats import projects as __PROJECTS__
 
-PROJECTS_DISCOVERED = False
+__PROJECTS_DISCOVERED = False
 
 
 def initialize_projects() -> None:
     """Scan the varats projects folder and initialize all projects from the
     found python files."""
-    global PROJECTS_DISCOVERED  # pylint: disable=global-statement
-    if not PROJECTS_DISCOVERED:
+    global __PROJECTS_DISCOVERED  # pylint: disable=global-statement
+    if not __PROJECTS_DISCOVERED:
         # Discover and initialize all projects
         __PROJECTS__.discover()
-        PROJECTS_DISCOVERED = True
+        __PROJECTS_DISCOVERED = True

--- a/varats/varats/tables/__init__.py
+++ b/varats/varats/tables/__init__.py
@@ -2,6 +2,10 @@
 
 import importlib
 import pkgutil
+from pathlib import Path
+
+import varats.utils.external_source_handling as esh
+from varats.utils.settings import vara_cfg
 
 
 def discover() -> None:
@@ -13,3 +17,8 @@ def discover() -> None:
         __all__.append(module_name)
         _module = importlib.import_module(module_name)
         globals()[module_name] = _module
+
+    extra_sources = vara_cfg()['external_source_repositories'].value
+    for p in [Path(p) for p in extra_sources]:
+        module_folder = esh.determine_project_source_root(p) / "tables"
+        esh.load_python_modules_from_external_project(p, module_folder, __all__)

--- a/varats/varats/tables/discover_tables.py
+++ b/varats/varats/tables/discover_tables.py
@@ -2,7 +2,12 @@
 
 from varats import tables as __TABLES__
 
+__TABLES_DISCOVERED = False
+
 
 def initialize_tables() -> None:
-    # Discover and initialize all plots
-    __TABLES__.discover()
+    global __TABLES_DISCOVERED  # pylint: disable=global-statement
+    if not __TABLES_DISCOVERED:
+        # Discover and initialize all plots
+        __TABLES__.discover()
+        __TABLES_DISCOVERED = True

--- a/varats/varats/tools/driver_run.py
+++ b/varats/varats/tools/driver_run.py
@@ -172,6 +172,7 @@ def main(
     )
 
     env = {k: str(to_yaml(v)) for k, v in bb_cfg().to_env_dict().items()}
+    env["PYTHONPATH"] = ":".join(sys.path)
 
     with local.cwd(vara_cfg()["benchbuild_root"].value):
         try:


### PR DESCRIPTION
Patches initializations methods to consider out-of-tree repositories when loading projects/experiments/reports/plots or tables.

Through the new config option 'external_source_repositories', users can provide a list of external sources for loading projects/etc.